### PR TITLE
Fix compiler error when using Rapier, clean up console output

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -296,15 +296,15 @@ pub fn build_map(
                                 collider.insert((bevy_rapier3d::prelude::RigidBody::Fixed,));
                             }
 
-                            for (mesh, texture_name) in meshes_to_spawn {
-                                if map_asset.material_handles.contains_key(texture_name) {
+                            for (texture_name, mesh) in meshes_to_spawn {
+                                if map_asset.material_handles.contains_key(&texture_name) {
                                     spawn_mesh_event.send(SpawnMeshEvent {
                                         map: map_entity,
                                         mesh: mesh,
                                         collider: Some(collider.id()),
                                         material: map_asset
                                             .material_handles
-                                            .get(texture_name)
+                                            .get(&texture_name)
                                             .unwrap()
                                             .clone(),
                                     });

--- a/src/build.rs
+++ b/src/build.rs
@@ -31,6 +31,14 @@ pub fn build_map(
     spawn_mesh_event: &mut EventWriter<SpawnMeshEvent>,
     post_build_map_event: &mut EventWriter<PostBuildMapEvent>,
 ) {
+    let geomap = map_asset.geomap.as_mut().unwrap();
+    // Filter out nodraw faces
+    geomap.faces.retain(|face_id| {
+        let texture_id = geomap.face_textures.get(face_id).unwrap();
+        let texture_name = geomap.textures.get(texture_id).unwrap();
+        texture_name != "__TB_empty"
+    });
+    // geomap doesn't need to be mut any more
     let geomap = map_asset.geomap.as_ref().unwrap();
 
     let face_trangle_planes = &geomap.face_planes;
@@ -169,13 +177,11 @@ pub fn build_map(
                     for face_id in brush_faces.iter() {
                         let texture_id = geomap.face_textures.get(face_id).unwrap();
                         let texture_name = geomap.textures.get(texture_id).unwrap();
-
+                        
                         let indices =
                             to_bevy_indecies(&face_triangle_indices.get(&face_id).unwrap());
                         let vertices =
                             to_bevy_vertices(&face_vertices.get(&face_id).unwrap(), &map_units);
-                        let normals = to_bevy_vec3s(&face_normals.get(&face_id).unwrap());
-                        let uvs = uvs_to_bevy_vec2s(&face_uvs.get(&face_id).unwrap());
                         brush_vertices.extend(vertices.clone());
 
                         // we don't render anything for these textures
@@ -183,9 +189,13 @@ pub fn build_map(
                             || texture_name == "clip"
                             || texture_name == "common/trigger"
                             || texture_name == "common/clip"
+                            || texture_name == "__TB_empty"
                         {
                             continue;
                         }
+
+                        let normals = to_bevy_vec3s(&face_normals.get(&face_id).unwrap());
+                        let uvs = uvs_to_bevy_vec2s(&face_uvs.get(&face_id).unwrap());
 
                         let mut mesh = Mesh::new(
                             PrimitiveTopology::TriangleList,


### PR DESCRIPTION
In #11 the collision mesh spawning was updated for Avian but not Rapier.

On both Avian and Rapier there's a bunch of warnings about __TB_empty not being found. We can skip those textures but still generate the collision mesh.
![image](https://github.com/user-attachments/assets/12017f7a-9fa6-4020-b7f2-62e86bacd72f)
