### PR TITLE
Update to Bevy 0.15, Rapier 0.28, Avian 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Quake .map files for the Bevy game engine."
 license = "MIT OR Apache-2.0"
 keywords = ["quake", "bevy", "game", "engine", "map", "bsp"]
 authors = [
-    "BrianWiz <https://github.com/BrianWiz>", 
+    "BrianWiz <https://github.com/BrianWiz>",
     "Zwazel <https://github.com/zwazel>",
     "Coreh <https://github.com/coreh>",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ authors = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bevy = "0.14.2"
+bevy = "0.15.0"
 qevy-derive = { path = "qevy-derive" }
 qevy-types = { path = "qevy-types" }
 anyhow = "1.0.89"
@@ -27,8 +27,9 @@ thiserror = "1.0.63"
 usage = "1.4.0"
 shalrath = "0.2.6"
 shambler = "0.2.0"
-avian3d = { version = "0.1.2", optional = true }
-bevy_rapier3d = { version = "0.27.0", optional = true }
+# TODO: Update to avian3d 0.2 once it's released
+avian3d = { git = "https://github.com/Jondolf/avian", rev = "c767b01", optional = true }
+bevy_rapier3d = { version = "0.28.0", optional = true }
 tracing = "0.1.40"
 serde = { version = "1.0.210", features = ["derive"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,7 @@ thiserror = "1.0.63"
 usage = "1.4.0"
 shalrath = "0.2.6"
 shambler = "0.2.0"
-# TODO: Update to avian3d 0.2 once it's released
-avian3d = { git = "https://github.com/Jondolf/avian", rev = "c767b01", optional = true }
+avian3d = { version = "0.2.0", optional = true }
 bevy_rapier3d = { version = "0.28.0", optional = true }
 tracing = "0.1.40"
 serde = { version = "1.0.210", features = ["derive"] }

--- a/examples/exporting_config.rs
+++ b/examples/exporting_config.rs
@@ -84,7 +84,7 @@ impl Default for APointClass {
             test_flag: EnumTestFlag::EnumVariantTest,
             test_choices: EnumTestChoices::EnumVariantTest,
             test_base_class: TestBaseClass,
-            test_color: Color::rgb(1.0, 0.5, 0.75), // some random color, idk
+            test_color: Color::srgb(1.0, 0.5, 0.75), // some random color, idk
             angles: QevyAngles::default(),
         }
     }

--- a/examples/first_person.rs
+++ b/examples/first_person.rs
@@ -63,11 +63,8 @@ fn main() {
 
 fn spawn_map(mut commands: Commands, asset_server: Res<AssetServer>) {
     // spawn the map
-    commands.spawn(qevy::components::MapBundle {
-        map: qevy::components::Map {
-            asset: asset_server.load("example.map"), // map must be under `assets` folder
-            ..default()
-        },
+    commands.spawn(qevy::components::Map {
+        asset: asset_server.load("example.map"), // map must be under `assets` folder
         ..default()
     });
 }
@@ -85,10 +82,7 @@ pub fn my_post_build_map_system(
         for (entity, props) in map_entities.iter_mut() {
             match props.classname.as_str() {
                 "spawn_point" => {
-                    commands.entity(entity).insert(TransformBundle {
-                        local: props.transform,
-                        ..default()
-                    });
+                    commands.entity(entity).insert(props.transform);
                 }
                 "monkey" => {
                     commands.entity(entity).insert((
@@ -112,18 +106,18 @@ pub fn my_post_build_map_system(
 
 fn spawn_character(mut commands: Commands, mut q_windows: Query<&mut Window, With<PrimaryWindow>>) {
     // spawn the camera
-    commands.spawn(Camera3dBundle {
-        camera: Camera {
+    commands.spawn((
+        Camera3d::default(),
+        Camera {
             hdr: true,
             ..default()
         },
-        projection: Projection::Perspective(PerspectiveProjection {
+        Projection::Perspective(PerspectiveProjection {
             fov: 1.5708,
             ..default()
         }),
-        transform: Transform::from_xyz(0.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
-        ..default()
-    });
+        Transform::from_xyz(0.0, 0.0, 0.0).looking_at(Vec3::ZERO, Vec3::Y),
+    ));
 
     // spawn the character
     let mut character = commands.spawn((
@@ -132,10 +126,7 @@ fn spawn_character(mut commands: Commands, mut q_windows: Query<&mut Window, Wit
         RigidBody::Dynamic,
         GravityScale(0.0),
         Rotation(Quat::IDENTITY),
-        TransformBundle {
-            local: Transform::from_xyz(0.0, 5.0, 0.0),
-            ..default()
-        },
+        Transform::from_xyz(0.0, 5.0, 0.0),
     ));
 
     #[cfg(feature = "avian")]

--- a/examples/first_person.rs
+++ b/examples/first_person.rs
@@ -91,15 +91,14 @@ pub fn my_post_build_map_system(
                     });
                 }
                 "monkey" => {
-                    commands.entity(entity).insert(PbrBundle {
-                        transform: props.transform,
-                        mesh: asset_server.load("models/monkey.gltf#Mesh0/Primitive0"),
-                        material: materials.add(StandardMaterial {
+                    commands.entity(entity).insert((
+                        props.transform,
+                        Mesh3d(asset_server.load("models/monkey.gltf#Mesh0/Primitive0")),
+                        MeshMaterial3d(materials.add(StandardMaterial {
                             base_color: Color::srgb(0.5, 0.5, 0.5),
                             ..default()
-                        }),
-                        ..default()
-                    });
+                        })),
+                    ));
                 }
                 _ => {}
             }
@@ -214,7 +213,7 @@ fn movement(
             // lerp camera to collider because otherwise it jitters due to physics steps
             camera_transform.translation = camera_transform.translation.lerp(
                 collider_transform.translation,
-                (1.0 / 60.0 * 1000.0) * time.delta_seconds(),
+                (1.0 / 60.0 * 1000.0) * time.delta_secs(),
             );
         }
     }
@@ -296,12 +295,12 @@ fn grab_mouse(
     let mut window = windows.single_mut();
 
     if mouse.just_pressed(MouseButton::Left) {
-        window.cursor.visible = false;
-        window.cursor.grab_mode = CursorGrabMode::Locked;
+        window.cursor_options.visible = false;
+        window.cursor_options.grab_mode = CursorGrabMode::Locked;
     }
 
     if key.just_pressed(KeyCode::Escape) {
-        window.cursor.visible = true;
-        window.cursor.grab_mode = CursorGrabMode::None;
+        window.cursor_options.visible = true;
+        window.cursor_options.grab_mode = CursorGrabMode::None;
     }
 }

--- a/qevy-derive/src/entities.rs
+++ b/qevy-derive/src/entities.rs
@@ -178,7 +178,7 @@ pub(crate) fn qevy_entity_derive_macro2(
                                 unreachable!("Default value is not a struct");
                             };
                             let property = field_registry.data::<ReflectQevyProperty>().expect(format!("Field type does not implement ReflectQevyProperty: {}", name).as_str());
-                            let property = property.get(mut_value.field(name).unwrap()).expect(format!("Field not found: {}", name).as_str());
+                            let property = property.get(mut_value.field(name).unwrap().try_as_reflect().unwrap()).expect(format!("Field not found: {}", name).as_str());
                             let property_string = property.get_fgd_string(name, description);
 
                             types_string.push_str(&property_string);

--- a/src/build.rs
+++ b/src/build.rs
@@ -296,15 +296,15 @@ pub fn build_map(
                                 collider.insert((bevy_rapier3d::prelude::RigidBody::Fixed,));
                             }
 
-                            for (mesh, texture_name) in meshes_to_spawn {
-                                if map_asset.material_handles.contains_key(texture_name) {
+                            for (texture_name, mesh) in meshes_to_spawn {
+                                if map_asset.material_handles.contains_key(&texture_name) {
                                     spawn_mesh_event.send(SpawnMeshEvent {
                                         map: map_entity,
                                         mesh: mesh,
                                         collider: Some(collider.id()),
                                         material: map_asset
                                             .material_handles
-                                            .get(texture_name)
+                                            .get(&texture_name)
                                             .unwrap()
                                             .clone(),
                                     });

--- a/src/build.rs
+++ b/src/build.rs
@@ -163,7 +163,6 @@ pub fn build_map(
                     .collect(),
                 ..default()
             },
-            SpatialBundle::default(),
         );
 
         commands.entity(map_entity).with_children(|children| {
@@ -231,8 +230,8 @@ pub fn build_map(
                         {
                             let mut collider = gchildren.spawn((
                                 convex_hull,
-                                TransformBundle::default(),
-                                VisibilityBundle::default(),
+                                Transform::default(),
+                                Visibility::default(),
                             ));
                             if classname == "trigger_multiple" {
                                 collider.insert((
@@ -279,8 +278,8 @@ pub fn build_map(
                         {
                             let mut collider = gchildren.spawn((
                                 convex_hull,
-                                TransformBundle::default(),
-                                VisibilityBundle::default(),
+                                Transform::default(),
+                                Visibility::default(),
                             ));
                             if classname == "trigger_multiple" {
                                 collider.insert((
@@ -374,9 +373,9 @@ pub fn post_build_map_system(
         for (entity, props) in map_entities.iter_mut() {
             match props.classname.as_str() {
                 "light" => {
-                    commands.entity(entity).insert(PointLightBundle {
-                        transform: props.transform,
-                        point_light: PointLight {
+                    commands.entity(entity).insert((
+                        props.transform,
+                        PointLight {
                             color: props.get_property_as_color("color", Color::WHITE),
                             radius: props.get_property_as_f32("radius", 0.0),
                             range: props.get_property_as_f32("range", 10.0),
@@ -384,20 +383,18 @@ pub fn post_build_map_system(
                             shadows_enabled: props.get_property_as_bool("shadows_enabled", false),
                             ..default()
                         },
-                        ..default()
-                    });
+                    ));
                 }
                 "directional_light" => {
-                    commands.entity(entity).insert(DirectionalLightBundle {
-                        transform: props.transform,
-                        directional_light: DirectionalLight {
+                    commands.entity(entity).insert((
+                        props.transform,
+                        DirectionalLight {
                             color: props.get_property_as_color("color", Color::WHITE),
                             illuminance: props.get_property_as_f32("illuminance", 10000.0),
                             shadows_enabled: props.get_property_as_bool("shadows_enabled", false),
                             ..default()
                         },
-                        ..default()
-                    });
+                    ));
                 }
                 "mover" => {
                     let mut mover_entity = commands.entity(entity);
@@ -417,10 +414,7 @@ pub fn post_build_map_system(
                             },
                             state: MoverState::default(),
                         },
-                        TransformBundle {
-                            local: Transform::from_xyz(0.0, 0.0, 0.0),
-                            ..default()
-                        },
+                        Transform::from_xyz(0.0, 0.0, 0.0),
                     ));
 
                     if let Some(mover_kind) =

--- a/src/build.rs
+++ b/src/build.rs
@@ -345,20 +345,18 @@ pub fn mesh_spawn_system(
         // if this mesh has a collider, make it a child of the collider
         if let Some(collider) = ev.collider {
             commands.entity(collider).with_children(|children| {
-                children.spawn(PbrBundle {
-                    mesh: meshes.add(ev.mesh.to_owned()),
-                    material: ev.material.to_owned(),
-                    ..default()
-                });
+                children.spawn((
+                    Mesh3d(meshes.add(ev.mesh.to_owned())),
+                    MeshMaterial3d(ev.material.to_owned()),
+                ));
             });
         // otherwise, it's a child of the map
         } else {
             commands.entity(ev.map).with_children(|children| {
-                children.spawn(PbrBundle {
-                    mesh: meshes.add(ev.mesh.to_owned()),
-                    material: ev.material.to_owned(),
-                    ..default()
-                });
+                children.spawn((
+                    Mesh3d(meshes.add(ev.mesh.to_owned())),
+                    MeshMaterial3d(ev.material.to_owned()),
+                ));
             });
         }
     }

--- a/src/build.rs
+++ b/src/build.rs
@@ -31,6 +31,14 @@ pub fn build_map(
     spawn_mesh_event: &mut EventWriter<SpawnMeshEvent>,
     post_build_map_event: &mut EventWriter<PostBuildMapEvent>,
 ) {
+    let geomap = map_asset.geomap.as_mut().unwrap();
+    // Filter out nodraw faces
+    geomap.faces.retain(|face_id| {
+        let texture_id = geomap.face_textures.get(face_id).unwrap();
+        let texture_name = geomap.textures.get(texture_id).unwrap();
+        texture_name != "__TB_empty"
+    });
+    // geomap doesn't need to be mut any more
     let geomap = map_asset.geomap.as_ref().unwrap();
 
     let face_trangle_planes = &geomap.face_planes;
@@ -169,13 +177,11 @@ pub fn build_map(
                     for face_id in brush_faces.iter() {
                         let texture_id = geomap.face_textures.get(face_id).unwrap();
                         let texture_name = geomap.textures.get(texture_id).unwrap();
-
+                        
                         let indices =
                             to_bevy_indecies(&face_triangle_indices.get(&face_id).unwrap());
                         let vertices =
                             to_bevy_vertices(&face_vertices.get(&face_id).unwrap(), &map_units);
-                        let normals = to_bevy_vec3s(&face_normals.get(&face_id).unwrap());
-                        let uvs = uvs_to_bevy_vec2s(&face_uvs.get(&face_id).unwrap());
                         brush_vertices.extend(vertices.clone());
 
                         // we don't render anything for these textures
@@ -183,9 +189,13 @@ pub fn build_map(
                             || texture_name == "clip"
                             || texture_name == "common/trigger"
                             || texture_name == "common/clip"
+                            || texture_name == "__TB_empty"
                         {
                             continue;
                         }
+
+                        let normals = to_bevy_vec3s(&face_normals.get(&face_id).unwrap());
+                        let uvs = uvs_to_bevy_vec2s(&face_uvs.get(&face_id).unwrap());
 
                         let mut mesh = Mesh::new(
                             PrimitiveTopology::TriangleList,

--- a/src/components.rs
+++ b/src/components.rs
@@ -2,11 +2,15 @@ use bevy::prelude::*;
 use std::{collections::BTreeMap, time::Duration};
 
 #[derive(Default, Component)]
+#[require(Transform, Visibility)]
 pub struct Map {
     pub asset: Handle<crate::MapAsset>,
 }
 
 #[derive(Default, Bundle)]
+#[deprecated(
+    note = "As of Bevy 0.15, bundles are deprecated in favor of required components. Use just `Map` instead, along with non-default values for `Transform` and `Visibility` if needed."
+)]
 pub struct MapBundle {
     pub map: Map,
     pub transform: TransformBundle,
@@ -95,6 +99,7 @@ impl MapEntityProperties {
 }
 
 #[derive(Default, Component)]
+#[require(Transform, Visibility)]
 pub struct BrushEntity;
 
 #[derive(Default, Component)]

--- a/src/gameplay_systems.rs
+++ b/src/gameplay_systems.rs
@@ -39,9 +39,6 @@ pub fn rapier_trigger_system(
 use avian3d::prelude::*;
 
 #[cfg(feature = "avian")]
-use bevy::utils::HashSet;
-
-#[cfg(feature = "avian")]
 pub fn avian_trigger_system(
     spatial_query: SpatialQuery,
     mut commands: Commands,

--- a/src/gameplay_systems.rs
+++ b/src/gameplay_systems.rs
@@ -6,7 +6,7 @@ use bevy_rapier3d::prelude::*;
 
 #[cfg(feature = "rapier")]
 pub fn rapier_trigger_system(
-    rapier_context: Res<RapierContext>,
+    rapier_context: ReadDefaultRapierContext,
     mut commands: Commands,
     trigger_once: Query<(Entity, &TriggerOnce), Without<TriggeredOnce>>,
     trigger_multiple: Query<(Entity, &TriggerMultiple)>,
@@ -73,15 +73,11 @@ pub fn avian_trigger_system(
             for (trigger_entity, trigger, gtransform, transform, collider) in
                 trigger_multiple.iter()
             {
-                let excluded = HashSet::from([map_entity]);
                 let intersections = spatial_query.shape_intersections(
                     collider,
                     gtransform.translation(),
                     transform.rotation,
-                    SpatialQueryFilter {
-                        excluded_entities: excluded,
-                        ..default()
-                    },
+                    &SpatialQueryFilter::from_excluded_entities([map_entity]),
                 );
 
                 for entity in intersections.iter() {
@@ -100,7 +96,7 @@ pub fn avian_trigger_system(
                     collider,
                     gtransform.translation(),
                     transform.rotation,
-                    SpatialQueryFilter::default(),
+                    &SpatialQueryFilter::default(),
                 );
 
                 for entity in intersections.iter() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,12 +7,12 @@ use std::collections::BTreeMap;
 use thiserror::Error;
 use tracing::info;
 
+pub mod auto_create_config;
 pub mod build;
 pub mod components;
 pub mod conversions;
 pub mod gameplay_systems;
 pub mod load;
-pub mod auto_create_config;
 
 #[derive(Debug, Asset, TypePath)]
 pub struct MapAsset {
@@ -44,11 +44,11 @@ impl AssetLoader for MapAssetLoader {
     type Asset = MapAsset;
     type Settings = ();
     type Error = MapAssetLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         load::load(reader, load_context, false).await
     }
@@ -65,11 +65,11 @@ impl AssetLoader for HeadlessMapAssetLoader {
     type Asset = MapAsset;
     type Settings = ();
     type Error = MapAssetLoaderError;
-    async fn load<'a>(
-        &'a self,
-        reader: &'a mut Reader<'_>,
-        _settings: &'a Self::Settings,
-        load_context: &'a mut LoadContext<'_>,
+    async fn load(
+        &self,
+        reader: &mut dyn Reader,
+        _settings: &Self::Settings,
+        load_context: &mut LoadContext<'_>,
     ) -> Result<Self::Asset, Self::Error> {
         load::load(reader, load_context, true).await
     }

--- a/src/load.rs
+++ b/src/load.rs
@@ -2,16 +2,13 @@ use crate::build::SpawnMeshEvent;
 use crate::{components::*, MapAssetLoaderError};
 use crate::{MapAsset, PostBuildMapEvent};
 use bevy::asset::io::Reader;
-use bevy::asset::AsyncReadExt;
 use bevy::asset::LoadContext;
 use bevy::asset::LoadedAsset;
+use bevy::image::{
+    CompressedImageFormats, ImageAddressMode, ImageSampler, ImageSamplerDescriptor, ImageType,
+};
 use bevy::prelude::*;
 use bevy::render::render_asset::RenderAssetUsages;
-use bevy::render::texture::CompressedImageFormats;
-use bevy::render::texture::ImageAddressMode;
-use bevy::render::texture::ImageSampler;
-use bevy::render::texture::ImageSamplerDescriptor;
-use bevy::render::texture::ImageType;
 use std::collections::BTreeMap;
 
 pub(crate) fn extensions() -> &'static [&'static str] {
@@ -19,7 +16,7 @@ pub(crate) fn extensions() -> &'static [&'static str] {
 }
 
 pub(crate) async fn load<'a>(
-    reader: &'a mut Reader<'_>,
+    reader: &'a mut dyn Reader,
     load_context: &'a mut LoadContext<'_>,
     headless: bool,
 ) -> Result<MapAsset, MapAssetLoaderError> {


### PR DESCRIPTION
This PR updates Qevy to be compatible with the latest Bevy, Avian and Rapier versions

- This is based off of #12 so it makes sense to merge that one first;
- As bundles are now deprecated in favor of required components, this PR replaces all uses of bundles,  migrates both `Map` and `BrushEntity` to use `#[require(Transform, Visibility)]`, and **deprecates `MapBundle`**.
- As `Handle<T>` is no longer a component, this PR replaces all uses of that with the wrapped forms (`Mesh3d`, `MeshMaterial3d`)
- We properly handle the newly introduced `PartialReflect` trait, by downcasting to `Reflect` where needed;
- ~~Avian 0.2 is not out yet, though it should be out soon [with very few, if any changes](https://discord.com/channels/691052431525675048/1124043933886976171/1317167099168161875), so this is using the latest `main` commit (`c767b01`) for now. Might make sense to wait for the version to be out before merging this, your call;~~ Avian 0.2 is now out.
- Updates some imports to use types that were extracted to `bevy_image`;
- Rapier migrated `Res<RapierContext>` to `ReadDefaultRapierContext` as it now supports multiple physics worlds, we update the code to use that.
